### PR TITLE
Hhpm 61 singleband rasters

### DIFF
--- a/src/hydro_health/engines/run_process_tiles.py
+++ b/src/hydro_health/engines/run_process_tiles.py
@@ -20,10 +20,9 @@ if __name__ == '__main__':
         'input_directory': Param(''),
         'output_directory': Param(str(OUTPUTS)),
         'eco_regions': Param('ER_3-Florida-West;'),
-        'drawn_polygon': Param(str(INPUTS / 'missing_tiles.geojson'))
+        'drawn_polygon': Param(str(OUTPUTS / 'drawn_polygons.geojson'))
         # 'drawn_polygon': Param('')
     }
-    # TODO figure out why tile_folder is empty again when trying to actually download tiles
     
     tiles = get_ecoregion_tiles(param_lookup)
     print(f'Selected tiles: {tiles.shape[0]}')

--- a/src/hydro_health/engines/tiling/TileProcessor.py
+++ b/src/hydro_health/engines/tiling/TileProcessor.py
@@ -5,17 +5,13 @@ import os
 import sys
 import geopandas as gpd
 import pathlib
-import rasterio
-from rasterio.mask import mask
-import pyproj
-from shapely.ops import transform
 import multiprocessing as mp
 import numpy as np
 
 from hydro_health.helpers import hibase_logging
 from botocore.client import Config
 from botocore import UNSIGNED
-from osgeo import gdal, ogr
+from osgeo import gdal
 
 
 mp.set_executable(os.path.join(sys.exec_prefix, 'pythonw.exe'))

--- a/src/hydro_health/engines/tiling/TileProcessor.py
+++ b/src/hydro_health/engines/tiling/TileProcessor.py
@@ -119,7 +119,7 @@ class TileProcessor:
         raster_ds = gdal.Open(tiff_file_path, gdal.GA_Update)
         no_data = -999999
         raster_array = raster_ds.ReadAsArray()
-        meters_array = np.where(raster_array > 0, no_data, raster_array)
+        meters_array = np.where(raster_array < 0, raster_array, no_data)
         raster_ds.GetRasterBand(1).WriteArray(meters_array)
         raster_ds.GetRasterBand(1).SetNoDataValue(no_data)  # took forever to find this gem
         raster_ds = None

--- a/src/hydro_health/engines/tiling/TileProcessor.py
+++ b/src/hydro_health/engines/tiling/TileProcessor.py
@@ -10,7 +10,8 @@ import boto3
 from hydro_health.helpers import hibase_logging
 from botocore.client import Config
 from botocore import UNSIGNED
-from rasterio.features import shapes
+from osgeo import gdal
+
 
 mp.set_executable(os.path.join(sys.exec_prefix, 'pythonw.exe'))
 
@@ -21,9 +22,13 @@ class TileProcessor:
 
         nbs_bucket = self.get_bucket()
         output_pathlib = pathlib.Path(output_folder)
-        tile_folder = False
+        tiff_file_path = False
         for obj_summary in nbs_bucket.objects.filter(Prefix=f"BlueTopo/{tile_id}"):
             output_tile_path = output_pathlib / obj_summary.key
+            # Store the path to the tile, not the xml
+            if output_tile_path.suffix == '.tiff':
+                tiff_file_path = output_tile_path
+
             tile_folder = output_tile_path.parents[0]
             if os.path.exists(output_tile_path):
                 self.write_message(f'Skipping: {output_tile_path.name}', output_folder)
@@ -32,8 +37,8 @@ class TileProcessor:
                 self.write_message(f'Downloading: {output_tile_path.name}', output_folder)
             tile_folder.mkdir(parents=True, exist_ok=True)   
             nbs_bucket.download_file(obj_summary.key, output_tile_path)
-        
-        return tile_folder
+
+        return tiff_file_path
 
     def get_bucket(self):
         """Connect to anonymous OCS S3 Bucket"""
@@ -52,28 +57,51 @@ class TileProcessor:
         """Obtain a multiprocessing Pool"""
 
         return mp.Pool(processes=processes)
-    
-    def write_message(self, message, output_folder):
-        with open(pathlib.Path(output_folder) / 'log_prints.txt', 'a') as writer:
-            writer.write(message + '\n')
-    
+
+    def multiband_to_singleband(self, tiff_file_path: pathlib.Path) -> None:
+        """Convert multiband BlueTopo raster into a singleband file"""
+        
+        multiband_tile_name = tiff_file_path.parents[0] / tiff_file_path.name
+        output_name = str(tiff_file_path.name).replace('_mb', '')
+        singleband_tile_name = tiff_file_path.parents[0] / output_name
+        gdal.Translate(
+            singleband_tile_name,
+            multiband_tile_name,
+            bandList=[1],
+            creationOptions=["COMPRESS:DEFLATE", "TILED:NO"],
+            callback=gdal.TermProgress_nocb
+        )
+
+    def rename_multiband(self, tiff_file_path) -> pathlib.Path:
+        """Update file name for singleband conversion"""
+
+        new_name = str(tiff_file_path).replace('.tiff', '_mb.tiff')
+        mb_tiff_file = tiff_file_path.replace(pathlib.Path(new_name))
+        return mb_tiff_file
+
     def process_tile(self, output_folder: str, index: int, row: gpd.GeoSeries):
         """Handle processing of a single tile"""
 
         tile_id = row[0]
-        tile_folder = self.download_nbs_tile(output_folder, tile_id)
-        # add general logging
-        if tile_folder:
-            # load tile
-            pass
-    
+        tiff_file_path = self.download_nbs_tile(output_folder, tile_id)
+        if tiff_file_path:
+            mb_tiff_file = self.rename_multiband(tiff_file_path)
+            self.multiband_to_singleband(mb_tiff_file)
+            mb_tiff_file.unlink()
+
     def process(self, tile_gdf: gpd.GeoDataFrame, outputs: str = False):
         with self.get_pool() as process_pool:
             results = [process_pool.apply_async(self.process_tile, [outputs, index, row]) for index, row in tile_gdf.iterrows()]
             for result in results:
+                # try to add logging here
+                # self.write_message(f'testing: {str(result)}', outputs)
                 result.get()
-        
+
         # log all tiles using tile_gdf
         tiles = list(tile_gdf['tile'])
         record = {'data_source': 'hydro_health', 'user': os.getlogin(), 'tiles_downloaded': len(tiles), 'tile_list': tiles}
         hibase_logging.send_record(record, table='bluetopo_test')  # TODO update to prod hibase
+
+    def write_message(self, message, output_folder):
+        with open(pathlib.Path(output_folder) / 'log_prints.txt', 'a') as writer:
+            writer.write(message + '\n')

--- a/src/hydro_health/engines/tiling/TileProcessor.py
+++ b/src/hydro_health/engines/tiling/TileProcessor.py
@@ -119,7 +119,7 @@ class TileProcessor:
         raster_ds = gdal.Open(tiff_file_path, gdal.GA_Update)
         no_data = -999999
         raster_array = raster_ds.ReadAsArray()
-        meters_array = np.where(raster_array < 0, raster_array, no_data)
+        meters_array = np.where(raster_array > 0, no_data, raster_array)
         raster_ds.GetRasterBand(1).WriteArray(meters_array)
         raster_ds.GetRasterBand(1).SetNoDataValue(no_data)  # took forever to find this gem
         raster_ds = None

--- a/src/hydro_health/helpers/tools.py
+++ b/src/hydro_health/helpers/tools.py
@@ -24,18 +24,24 @@ def create_raster_vrt(output_folder: str) -> None:
     """Create an output VRT from found .tif files"""
 
     outputs = pathlib.Path(output_folder) / 'BlueTopo' if output_folder else OUTPUTS / 'BlueTopo'
-
     geotiffs = list(outputs.rglob('*.tiff'))
-    vrt_filename = str(outputs / 'bluetopo_mosaic.vrt')
-    gdal.BuildVRT(vrt_filename, geotiffs, callback=gdal.TermProgress_nocb)
-
-    # Build a compressed single raster
-    # final_image = gdal.Open(vrt_filename, gdal.GA_ReadOnly)
-    # gdal.Translate(str(outputs / 'bluetopo_final.tif'), final_image, format='GTiff',
-    #            creationOptions=['COMPRESS:DEFLATE', 'TILED:YES'],
-    #            callback=gdal.TermProgress_nocb)
-    # final_image = None
-
+    
+    output_geotiffs = {}
+    for geotiff in geotiffs:
+        # make separate VRT files for each CRS
+        geotiff_ds = gdal.Open(geotiff)
+        projection_wkt = geotiff_ds.GetProjection()
+        spatial_ref = osr.SpatialReference(wkt=projection_wkt)
+        projected_crs_string = spatial_ref.GetAttrValue('projcs')
+        clean_crs_string = projected_crs_string.replace('/', '').replace(' ', '_')
+        if clean_crs_string not in output_geotiffs:
+            output_geotiffs[clean_crs_string] = []
+        output_geotiffs[clean_crs_string].append(geotiff)
+        geotiff_ds = None
+    
+    for crs, tiles in output_geotiffs.items():
+        vrt_filename = str(outputs / f'bluetopo_mosaic_{crs}.vrt')
+        gdal.BuildVRT(vrt_filename, tiles, callback=gdal.TermProgress_nocb)
 
 def get_config_item(parent: str, child: str=False) -> tuple[str, int]:
     """Load config and return speciific key"""


### PR DESCRIPTION
Tool now has a couple steps after downloading tiles.  Multiband rasters are converted to singleband rasters.  The multiband file is deleted to conserve space.  Positive elevation values also are set to "no data" for all of the singleband tiles. 
The tool currently creates separate VRT files for each coordinate system found across all tiles.  This is a quick way to view the full extent of all tiles downloaded.  