### PR TITLE
Added ID to provider folders to fix overwriting

### DIFF
--- a/inputs/run_configs/hydro_health_session_08132025.yaml
+++ b/inputs/run_configs/hydro_health_session_08132025.yaml
@@ -15,5 +15,4 @@ steps:
   run: false
 - tool: run_sediment_layer_engine
   run: false
-runtimes:
-- 08222025
+runtimes: []

--- a/src/hydro_health/engines/tiling/DigitalCoastEngine.py
+++ b/src/hydro_health/engines/tiling/DigitalCoastEngine.py
@@ -209,21 +209,15 @@ class DigitalCoastEngine:
             if not self.approved_dataset(feature):
                 continue
             folder_name = re.sub('\W+',' ', feature['attributes']['provider_results_name']).strip().replace(' ', '_') + '_' + str(feature['attributes']['Year'])  # remove illegal chars
-            output_folder_path = pathlib.Path(outputs) / ecoregion_id / get_config_item('DIGITALCOAST', 'SUBFOLDER') / 'DigitalCoast' / folder_name
+            output_folder_path = pathlib.Path(outputs) / ecoregion_id / get_config_item('DIGITALCOAST', 'SUBFOLDER') / 'DigitalCoast' / f"{folder_name}_{feature['attributes']['ID']}"
             output_folder_path.mkdir(parents=True, exist_ok=True)
 
             # Write out JSON
             output_json = pathlib.Path(output_folder_path) / 'feature.json'
-            if os.path.exists(output_json):
-                # Read the existing json
-                with open(output_json) as reader:
-                    provider_json = json.load(reader)
-                    external_provider_links = provider_json['ExternalProviderLink']
-            else:
-                external_provider_links = json.loads(feature['attributes']['ExternalProviderLink'])['links']
-                feature['attributes']['ExternalProviderLink'] = external_provider_links
-                with open(output_json, 'a') as writer:
-                    writer.write(json.dumps(feature['attributes'], indent=4))
+            external_provider_links = json.loads(feature['attributes']['ExternalProviderLink'])['links']
+            feature['attributes']['ExternalProviderLink'] = external_provider_links
+            with open(output_json, 'a') as writer:
+                writer.write(json.dumps(feature['attributes'], indent=4))
 
             for external_data in external_provider_links:
                 if external_data['label'] == 'Bulk Download':


### PR DESCRIPTION
Added ID to Digital Coast provider folders to make them unique by project instead of data type in Digital Coast.  
We had been overwriting provider folders previously and not getting the full scope of data covering areas of interest.